### PR TITLE
Updated multi-value options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Checks if your categories' slugs match existing categories in your community.
 
 ```bash
 ThunderPipe validate categories <community> \
-	--categories <category1> \
-	--categories <category2>
+	--category <category1> \
+	--category <category2>
 ```
 
 | Argument      | Description            |

--- a/ThunderPipe/Settings/PublishSettings.cs
+++ b/ThunderPipe/Settings/PublishSettings.cs
@@ -35,7 +35,7 @@ public sealed class PublishSettings : CommandSettings
 	[TypeConverter(typeof(UriTypeConverter))]
 	public Uri? Repository { get; init; }
 
-	[CommandOption("--categories <VALUES>")]
+	[CommandOption("--category <CATEGORY>")]
 	[Description("Categories used to label this package")]
 	public string[]? Categories { get; init; }
 

--- a/ThunderPipe/Settings/ValidateCategoriesSettings.cs
+++ b/ThunderPipe/Settings/ValidateCategoriesSettings.cs
@@ -17,7 +17,7 @@ public sealed class ValidateCategoriesSettings : ValidateSettings
 	[Description("Community where the package will be published")]
 	public required string Community { get; init; }
 
-	[CommandOption("--categories <VALUES>")]
+	[CommandOption("--category <CATEGORY>")]
 	[Description("Categories that will be used to label the package")]
 	public string[]? Categories { get; init; }
 


### PR DESCRIPTION
Updated the multi-value options to use the singular unit as the flag. For example, for categories, instead of using `--categories`, it uses `--category`.

This is to make it easier to read and understand, as it tells the user that `--category <category>` must have only one category instead of all.