### PR TITLE
update Sdk install instructions

### DIFF
--- a/ThunderPipe.Sdk/README.md
+++ b/ThunderPipe.Sdk/README.md
@@ -14,7 +14,7 @@ of [ThunderPipe.Core](https://github.com/WarperSan/ThunderPipe/tree/master/Thund
 
 ## Installation
 
-Go to <https://www.nuget.org/packages/ThunderPipe.Sdk> and copy the Sdk xml node for the latest version into your project (looks something like this):
+Go to [NuGet](https://www.nuget.org/packages/ThunderPipe.Sdk), and copy the Sdk XML node for the latest version into your project:
 
 ```xml
 <Sdk Name="ThunderPipe.Sdk" Version="version.number.here" />

--- a/ThunderPipe.Sdk/README.md
+++ b/ThunderPipe.Sdk/README.md
@@ -14,10 +14,10 @@ of [ThunderPipe.Core](https://github.com/WarperSan/ThunderPipe/tree/master/Thund
 
 ## Installation
 
-You can install and use ThunderPipe.Sdk by adding the following line to your `.csproj`:
+Go to <https://www.nuget.org/packages/ThunderPipe.Sdk> and copy the Sdk xml node for the latest version into your project (looks something like this):
 
 ```xml
-<Sdk Name="ThunderPipe.Sdk" Version="0.1.1" />
+<Sdk Name="ThunderPipe.Sdk" Version="version.number.here" />
 ```
 
 ## Tasks


### PR DESCRIPTION
The version property is required for sdks, but making sure it is up to date in the readme is annoying, so instruct users to copy the xml node from nuget instead where it's up to date so users don't use an old version.